### PR TITLE
Task 4: Add scan result indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Go.sum files, course requirement
+*.sum

--- a/task-4/cmd/go-search/go.mod
+++ b/task-4/cmd/go-search/go.mod
@@ -1,0 +1,13 @@
+module dersnek/task-4/cmd/go-search
+
+go 1.15
+
+replace dersnek/task-4/pkg/crawler v0.0.0 => ../../pkg/crawler
+replace dersnek/task-4/pkg/crawler/spider v0.0.0 => ../../pkg/crawler/spider
+replace dersnek/task-4/pkg/engine v0.0.0 => ../../pkg/engine
+replace dersnek/task-4/pkg/index v0.0.0 => ../../pkg/index
+
+require dersnek/task-4/pkg/crawler v0.0.0
+require dersnek/task-4/pkg/crawler/spider v0.0.0
+require dersnek/task-4/pkg/engine v0.0.0
+require dersnek/task-4/pkg/index v0.0.0

--- a/task-4/cmd/go-search/main.go
+++ b/task-4/cmd/go-search/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"dersnek/task-4/pkg/crawler"
+	"dersnek/task-4/pkg/crawler/spider"
+	"dersnek/task-4/pkg/engine"
+	"dersnek/task-4/pkg/index"
+	"fmt"
+	"os"
+)
+
+func main() {
+	urls := []string{"https://katata.games", "https://go.dev"}
+	indexer := index.New()
+	scanner := spider.New()
+	engine := engine.New()
+
+	scanRes, err := scan(scanner, urls)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	indexer.Process(scanRes)
+
+	for {
+		q := ""
+
+		fmt.Printf("\n------------------------------------\n")
+		fmt.Printf("Search query: ")
+
+		bscanner := bufio.NewScanner(os.Stdin)
+		for bscanner.Scan() {
+			q = bscanner.Text()
+			break
+		}
+
+		fmt.Printf("------------------------------------\n")
+
+		if q == "" {
+			continue
+		}
+
+		res := engine.Find(q, indexer)
+
+		printResults(res)
+	}
+}
+
+func scan(scanner crawler.Interface, urls []string) ([]crawler.Document, error) {
+	res := []crawler.Document{}
+
+	for i := 0; i < len(urls); i++ {
+		fmt.Printf("Scanning %s...", urls[i])
+
+		data, err := scanner.Scan(urls[i], 2)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, d := range data {
+			res = append(res, d)
+		}
+
+		fmt.Printf(" done!\n")
+	}
+
+	return res, nil
+}
+
+func printResults(res map[string]string) {
+	fmt.Printf("\n%v results\n", len(res))
+	for k, v := range res {
+		fmt.Println()
+		fmt.Println(k)
+		fmt.Println(v)
+	}
+}

--- a/task-4/pkg/crawler/crawler.go
+++ b/task-4/pkg/crawler/crawler.go
@@ -1,0 +1,13 @@
+package crawler
+
+// Document - webpage, scanned by a crawler. Page body is not saved.
+type Document struct {
+	ID    uint
+	URL   string
+	Title string
+}
+
+// Interface определяет контракт поискового робота.
+type Interface interface {
+	Scan(url string, depth int) ([]Document, error)
+}

--- a/task-4/pkg/crawler/go.mod
+++ b/task-4/pkg/crawler/go.mod
@@ -1,0 +1,5 @@
+module dersnek/task-4/pkg/crawler
+
+go 1.15
+
+require golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0

--- a/task-4/pkg/crawler/membot/go.mod
+++ b/task-4/pkg/crawler/membot/go.mod
@@ -1,0 +1,3 @@
+module dersnek/task-4/pkg/crawler/membot
+
+go 1.15

--- a/task-4/pkg/crawler/membot/membot.go
+++ b/task-4/pkg/crawler/membot/membot.go
@@ -1,0 +1,33 @@
+package membot
+
+import (
+	"gosearch/pkg/crawler"
+)
+
+// Service - имитация служба поискового робота.
+type Service struct{}
+
+// New - констрктор имитации службы поискового робота.
+func New() *Service {
+	s := Service{}
+	return &s
+}
+
+// Scan возвращает заранее подготовленный набор данных
+func (s *Service) Scan(url string, depth int) ([]crawler.Document, error) {
+
+	data := []crawler.Document{
+		{
+			ID:    0,
+			URL:   "https://yandex.ru",
+			Title: "Яндекс",
+		},
+		{
+			ID:    1,
+			URL:   "https://google.ru",
+			Title: "Google",
+		},
+	}
+
+	return data, nil
+}

--- a/task-4/pkg/crawler/spider/go.mod
+++ b/task-4/pkg/crawler/spider/go.mod
@@ -1,0 +1,8 @@
+module dersnek/task-4/pkg/crawler/spider
+
+go 1.15
+
+replace dersnek/task-4/pkg/crawler v0.0.0 => ../
+
+require dersnek/task-4/pkg/crawler v0.0.0
+require golang.org/x/net v0.0.0-20201031054903-ff519b6c9102

--- a/task-4/pkg/crawler/spider/spider.go
+++ b/task-4/pkg/crawler/spider/spider.go
@@ -1,0 +1,123 @@
+// Package spider реализует сканер содержимого веб-сайтов.
+// Пакет позволяет получить список ссылок и заголовков страниц внутри веб-сайта по его URL.
+package spider
+
+import (
+	"dersnek/task-4/pkg/crawler"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// Service - служба поискового робота.
+type Service struct{}
+
+// New - конструктор службы поискового робота.
+func New() *Service {
+	s := Service{}
+	return &s
+}
+
+// Scan осуществляет рекурсивный обход ссылок сайта, указанного в URL,
+// с учётом глубины перехода по ссылкам, переданной в depth.
+func (s *Service) Scan(url string, depth int) (data []crawler.Document, err error) {
+	pages := make(map[string]string)
+
+	parse(url, url, depth, pages)
+
+	for url, title := range pages {
+		item := crawler.Document{
+			URL:   url,
+			Title: title,
+		}
+		data = append(data, item)
+	}
+
+	return data, nil
+}
+
+// parse рекурсивно обходит ссылки на странице, переданной в url.
+// Глубина рекурсии задаётся в depth.
+// Каждая найденная ссылка записывается в ассоциативный массив
+// data вместе с названием страницы.
+func parse(url, baseurl string, depth int, data map[string]string) error {
+	if depth == 0 {
+		return nil
+	}
+
+	response, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	page, err := html.Parse(response.Body)
+	if err != nil {
+		return err
+	}
+
+	data[url] = pageTitle(page)
+
+	if depth == 1 {
+		return nil
+	}
+	links := pageLinks(nil, page)
+	for _, link := range links {
+		link = strings.TrimSuffix(link, "/")
+		// относительная ссылка
+		if strings.HasPrefix(link, "/") && len(link) > 1 {
+			link = baseurl + link
+		}
+		// ссылка уже отсканирована
+		if data[link] != "" {
+			continue
+		}
+		// ссылка содержит базовый url полностью
+		if strings.HasPrefix(link, baseurl) {
+			parse(link, baseurl, depth-1, data)
+		}
+	}
+
+	return nil
+}
+
+// pageTitle осуществляет рекурсивный обход HTML-страницы и возвращает значение элемента <tittle>.
+func pageTitle(n *html.Node) string {
+	var title string
+	if n.Type == html.ElementNode && n.Data == "title" && n.FirstChild != nil {
+		return n.FirstChild.Data
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		title = pageTitle(c)
+		if title != "" {
+			break
+		}
+	}
+	return title
+}
+
+// pageLinks рекурсивно сканирует узлы HTML-страницы и возвращает все найденные ссылки без дубликатов.
+func pageLinks(links []string, n *html.Node) []string {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, a := range n.Attr {
+			if a.Key == "href" {
+				if !sliceContains(links, a.Val) {
+					links = append(links, a.Val)
+				}
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		links = pageLinks(links, c)
+	}
+	return links
+}
+
+// sliceContains возвращает true если массив содержит переданное значение
+func sliceContains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/task-4/pkg/engine/engine.go
+++ b/task-4/pkg/engine/engine.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"dersnek/task-4/pkg/crawler"
+	"dersnek/task-4/pkg/index"
+	"sort"
+	"strings"
+)
+
+// Service - search engine service
+type Service struct{}
+
+// New - creates and returns a new engine service
+func New() *Service {
+	return &Service{}
+}
+
+// Find - finds documents (webpages) containing words present in the query string
+func (s *Service) Find(q string, i *index.Service) map[string]string {
+	res := make(map[string]string)
+	qWords := strings.Split(strip(q), " ")
+
+	for _, w := range qWords {
+		wRes := findByWord(w, i)
+
+		for _, d := range wRes {
+			if res[d.URL] != d.Title {
+				res[d.URL] = d.Title
+			}
+		}
+	}
+
+	return res
+}
+
+func findByWord(w string, s *index.Service) []crawler.Document {
+	res := []crawler.Document{}
+
+	ids, found := s.Data[w]
+	if !found {
+		return res
+	}
+
+	for _, id := range ids {
+		i := sort.Search(len(s.Store), func(i int) bool { return (s.Store[i]).ID >= id })
+		if i < len(s.Store) && s.Store[i].ID == id {
+			res = append(res, s.Store[i])
+		}
+	}
+
+	return res
+}
+
+func strip(s string) string {
+	var result strings.Builder
+	result.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if ('a' <= b && b <= 'z') ||
+			('A' <= b && b <= 'Z') ||
+			('0' <= b && b <= '9') ||
+			b == ' ' {
+			result.WriteByte(b)
+		}
+	}
+	return result.String()
+}

--- a/task-4/pkg/engine/go.mod
+++ b/task-4/pkg/engine/go.mod
@@ -1,0 +1,9 @@
+module dersnek/task-4/pkg/engine
+
+go 1.15
+
+replace dersnek/task-4/pkg/crawler v0.0.0 => ../crawler
+replace dersnek/task-4/pkg/index v0.0.0 => ../index
+
+require dersnek/task-4/pkg/crawler v0.0.0
+require dersnek/task-4/pkg/index v0.0.0

--- a/task-4/pkg/index/go.mod
+++ b/task-4/pkg/index/go.mod
@@ -1,0 +1,7 @@
+module dersnek/task-4/pkg/index
+
+go 1.15
+
+replace dersnek/task-4/pkg/crawler v0.0.0 => ../crawler
+
+require dersnek/task-4/pkg/crawler v0.0.0

--- a/task-4/pkg/index/index.go
+++ b/task-4/pkg/index/index.go
@@ -1,0 +1,102 @@
+// Package index indexes, stores and retrieves webpages
+package index
+
+import (
+	"dersnek/task-4/pkg/crawler"
+	"sort"
+	"strings"
+)
+
+// Service - search index service
+type Service struct {
+	Store  []crawler.Document
+	Data   Data
+	LastID uint
+}
+
+// New - creates and returns a new index service
+func New() *Service {
+	return &Service{
+		Data:   make(Data),
+		LastID: 0,
+	}
+}
+
+// Data contains a hashmap with words as keys and as values -
+// an array of IDs of documents (webpages) containing given word.
+type Data map[string][]uint
+
+type wordIDPair struct {
+	word string
+	id   uint
+}
+
+var stopWords = []string{
+	"a", "and", "around", "every", "for", "from", "in",
+	"is", "it", "not", "on", "one", "the", "to", "under"}
+
+// Process stores array of crawler.Documents
+// and build an inverted index for them
+func (s *Service) Process(docs []crawler.Document) {
+	allWordIDPairs := []wordIDPair{}
+
+	// Extract all words from all docs into an array
+	for i, d := range docs {
+		gID := s.LastID + uint(i)
+
+		// Store doc
+		d.ID = gID
+		s.Store = append(s.Store, d)
+
+		docWords := strings.Split(strip(d.Title), " ")
+
+		for _, w := range docWords {
+			widp := wordIDPair{word: w, id: gID}
+			allWordIDPairs = append(allWordIDPairs, widp)
+		}
+	}
+
+	// Convert all words to lowercase
+	for i, wdp := range allWordIDPairs {
+		allWordIDPairs[i].word = strings.ToLower(wdp.word)
+	}
+
+	// Filter out stop words
+	filtWordIDPairs := []wordIDPair{}
+
+	for _, widp := range allWordIDPairs {
+		if !contains(stopWords, widp.word) {
+			filtWordIDPairs = append(filtWordIDPairs, widp)
+		}
+	}
+
+	for _, widp := range filtWordIDPairs {
+		s.Data[widp.word] = append(s.Data[widp.word], widp.id)
+	}
+
+	sort.Slice(s.Store, func(i, j int) bool { return s.Store[i].ID < s.Store[j].ID })
+}
+
+func strip(s string) string {
+	var result strings.Builder
+	result.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if ('a' <= b && b <= 'z') ||
+			('A' <= b && b <= 'Z') ||
+			('0' <= b && b <= '9') ||
+			b == ' ' {
+			result.WriteByte(b)
+		}
+	}
+	return result.String()
+}
+
+func contains(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**Разработка быстрого поискового индекса.**

Для быстрого поиска слов в документах используется обратный индекс (ru.wikipedia.org). Поскольку индекс отсортирован, то для можно воспользоваться бинарным поиском для ускорения поисковой выдачи.


**- Создать обратный индекс для документов. Разместить индекс в пакете «index».** 


Теперь поисковый робот должен передавать документы на индексирование. Проиндексированные документы должны храниться в объекте из пакета «index». Документы должны быть представлены в виде структуры данных. При этом для каждого документа нужно добавить его номер – поле в структуре данных вместе с URL и Title.
Массив документов должен быть отсортирован по номерам, используя сортировку из стандартной библиотеки.


**- Переделать метод поисковой выдачи на использование индекса.** 


Для поиска по индексу поисковый движок должен импортировать поисковый индекс из пакета «index» как зависимость и искать по индексу, а не по массиву документов. Поиск по индексу должен выдавать номера документов (поле в структуре данных документа).


**- Использовать бинарный поиск по массиву документов (по номерам документов).** 


Можно воспользоваться стандартной библиотекой или написать свою реализацию. 